### PR TITLE
Fix setup and validation scripts for current GenesisLab APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Hardware compatibility follows the official Genesis runtime environment and back
 ```bash
 conda create -n genesislab python=3.10
 conda activate genesislab
-````
+```
 
 ```bash
 pip install genesis-world
@@ -145,9 +145,8 @@ python scripts/test/test_engine.py --backend cpu --num-envs 4
 Run sanity checks to verify stepping logic and vectorized rollouts.
 
 ```bash
-python scripts/test/test_env.py
 python scripts/test/test_env_vectorized.py
-python scripts/test/test_random_rollout.py
+python scripts/test/test_env_random_rollout.py
 ```
 </detail>
 
@@ -188,7 +187,6 @@ genesislab
 │   │   └── setup_ext.sh
 │   └── test
 │       ├── test_engine.py
-│       ├── test_env.py
 │       ├── test_env_vectorized.py
 │       └── test_random_rollout.py
 │
@@ -212,7 +210,7 @@ A typical workflow for implementing a new RL environment is:
 Recommended validation scripts:
 
 ```
-test_env.py
+test_engine.py
 test_env_vectorized.py
 test_random_rollout.py
 ```

--- a/scripts/setup/setup_ext.sh
+++ b/scripts/setup/setup_ext.sh
@@ -164,4 +164,8 @@ done < <(EXT_YAML_FILE="$EXT_YAML_FILE" parse_ext_yaml)
 
 install_modules "${editable_modules[@]}"
 
+echo "🧩 Installing additional Python dependencies..."
+pip install pyyaml tensorboard prettytable gymnasium --quiet
+echo "✅ Dependencies installed."
+
 echo "✅ External setup completed."

--- a/scripts/setup/setup_ext.yaml
+++ b/scripts/setup/setup_ext.yaml
@@ -1,3 +1,4 @@
+#YAML config for external dependencies
 repos:
   - name: assetslib
     url: git@github.com:Renforce-Dynamics/assetslib.git
@@ -7,4 +8,5 @@ repos:
 editable_modules:
   - ./source/genesislab
   - ./source/genesis_tasks
-
+  - ./source/genesis_assets
+  - ./source/genesis_rl

--- a/scripts/test/test_engine.py
+++ b/scripts/test/test_engine.py
@@ -18,7 +18,8 @@ import genesis as gs
 import torch
 
 from genesislab.components.entities.scene_cfg import SceneCfg
-from genesislab.components.entities.robot_cfg import RobotCfg
+from genesislab.engine.assets.robot_cfg import RobotCfg
+from genesislab.components.entities.terrain_cfg import TerrainCfg
 from genesislab.engine.binding import GenesisBinding
 
 
@@ -32,8 +33,10 @@ def test_engine_binding(num_envs: int = 4, backend: str = "cpu") -> bool:
     # Create a simple scene config
     scene_cfg = SceneCfg(
         num_envs=num_envs,
-        dt=0.002,
-        substeps=1,
+        sim_options=SceneCfg.SimOptionsCfg(
+            dt=0.002,
+            substeps=1,
+        ),
         backend=backend,
         robots={
             "robot": RobotCfg(
@@ -43,7 +46,7 @@ def test_engine_binding(num_envs: int = 4, backend: str = "cpu") -> bool:
                 fixed_base=False,
             )
         },
-        terrain={"type": "plane"},
+        terrain=TerrainCfg(type="plane"),
     )
 
     # Create binding

--- a/scripts/test/test_env_random_rollout.py
+++ b/scripts/test/test_env_random_rollout.py
@@ -14,10 +14,10 @@ from typing import TYPE_CHECKING
 import genesis as gs
 import torch
 
-from genesislab.envs.manager_based_rl_env import ManagerBasedRlEnvCfg
-from genesislab.components.entities.robot_cfg import RobotCfg
+from genesislab.envs.manager_based_rl_env import ManagerBasedRlEnv, ManagerBasedRlEnvCfg
+from genesislab.engine.assets.robot_cfg import RobotCfg
 from genesislab.components.entities.scene_cfg import SceneCfg
-from genesislab.envs import ManagerBasedGenesisEnv
+from genesislab.components.entities.terrain_cfg import TerrainCfg
 from genesislab.managers.action_manager import ActionTerm, ActionTermCfg
 from genesislab.managers.observation_manager import ObservationGroupCfg, ObservationTermCfg
 from genesislab.managers.reward_manager import RewardTermCfg
@@ -39,9 +39,9 @@ class DemoActionTermCfg(ActionTermCfg):
 class DemoActionTerm(ActionTerm):
     """Minimal action term that directly maps actions to joint position targets."""
 
-    def __init__(self, cfg: DemoActionTermCfg, env: "_MBEnv"):
+    def __init__(self, cfg: ActionTermCfg, env: "_MBEnv"):
         super().__init__(cfg, env)
-        dof_pos, _ = env._binding.get_joint_state(cfg.entity_name)
+        dof_pos, _ = env.scene.querier.get_joint_state(cfg.entity_name)
         self._action_dim = dof_pos.shape[-1]
         self._raw_action = torch.zeros((self.num_envs, self._action_dim), device=self.device)
         self._targets = torch.zeros_like(self._raw_action)
@@ -67,7 +67,7 @@ class DemoActionTerm(ActionTerm):
         self._targets[:] = actions
 
     def apply_actions(self) -> None:
-        self._env._binding.set_joint_targets(
+        self._env.scene.controller.set_joint_targets(
             self.cfg.entity_name,
             self._targets,
             control_type="position",
@@ -85,8 +85,10 @@ def test_random_rollout():
     # Create a minimal environment config using the Go2 asset
     scene_cfg = SceneCfg(
         num_envs=4,
-        dt=0.002,
-        substeps=1,
+        sim_options=SceneCfg.SimOptionsCfg(
+            dt=0.002,
+            substeps=1,
+        ),
         backend=backend_str,
         robots={
             "go2": RobotCfg(
@@ -97,24 +99,22 @@ def test_random_rollout():
                 control_dofs=None,  # Control all DOFs
             )
         },
-        terrain={"type": "plane"},
+        terrain=TerrainCfg(type="plane"),
     )
+
+    @configclass
+    class PolicyCfg(ObservationGroupCfg):
+        dof_pos: ObservationTermCfg = ObservationTermCfg(
+            func=lambda env: env.entities["go2"].data.joint_pos,
+        )
 
     env_cfg = ManagerBasedRlEnvCfg(
         decimation=10,
         scene=scene_cfg,
-        observations={
-            "policy": ObservationGroupCfg(
-                terms={
-                    "dof_pos": ObservationTermCfg(
-                        func=lambda env: env._binding.get_joint_state("go2")[0],
-                    ),
-                },
-                concatenate_terms=True,
-            )
-        },
+        observations={"policy": PolicyCfg(concatenate_terms=True)},
         actions={
-            "go2": DemoActionTermCfg(
+            "go2": ActionTermCfg(
+                class_type=DemoActionTerm,
                 entity_name="go2",
             )
         },
@@ -126,7 +126,7 @@ def test_random_rollout():
         },
         terminations={
             "fall": TerminationTermCfg(
-                func=lambda env: env._binding.get_root_state("go2")[0][:, 2] < 0.1,
+                func=lambda env: env.entities["go2"].data.root_pos_w[:, 2] < 0.1,
                 time_out=False,
             )
         },
@@ -136,7 +136,7 @@ def test_random_rollout():
 
     # Create environment
     print("Creating environment...")
-    env = ManagerBasedGenesisEnv(cfg=env_cfg, device=backend_str)
+    env = ManagerBasedRlEnv(cfg=env_cfg, device=backend_str)
     print(f"✓ Environment created with {env.num_envs} environments")
 
     # Reset

--- a/scripts/test/test_env_vectorized.py
+++ b/scripts/test/test_env_vectorized.py
@@ -91,7 +91,8 @@ def test_vectorized(
         traceback.print_exc()
         return False
 
-    scene = env._binding.scene
+    # Access scene for potential video recording
+    scene = env._scene
     # Test reset
     print("\nTesting reset...")
     try:

--- a/source/genesislab/genesislab/engine/binding.py
+++ b/source/genesislab/genesislab/engine/binding.py
@@ -1,0 +1,108 @@
+"""GenesisBinding: Engine binding wrapper for GenesisLab.
+
+This module provides the GenesisBinding class that wraps the LabScene
+and related components to provide a unified interface for engine operations.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import torch
+
+if TYPE_CHECKING:
+    from genesislab.components.entities.scene_cfg import SceneCfg
+
+
+class GenesisBinding:
+    """Unified engine binding for GenesisLab.
+
+    This class wraps LabScene and provides a simplified interface for
+    scene management, state queries, and physics control.
+    """
+
+    def __init__(self, cfg: "SceneCfg", device: str = "cuda"):
+        """Initialize the Genesis binding.
+
+        Args:
+            cfg: Scene configuration.
+            device: Device to use for tensors ('cuda' or 'cpu').
+        """
+        from genesislab.engine.scene.lab_scene import LabScene
+
+        self._scene = LabScene(cfg, device=device)
+        self._device = device
+
+    @property
+    def num_envs(self) -> int:
+        """Number of parallel environments."""
+        return self._scene.num_envs
+
+    @property
+    def device(self) -> str:
+        """Device being used."""
+        return self._device
+
+    def build(self, env: any = None) -> None:
+        """Build the Genesis scene and entities.
+
+        Args:
+            env: Optional environment instance for entity construction.
+        """
+        self._scene.build(env=env)
+
+    def get_joint_state(self, entity_name: str) -> tuple[torch.Tensor, torch.Tensor]:
+        """Get joint positions and velocities for an entity.
+
+        Args:
+            entity_name: Name of the entity.
+
+        Returns:
+            Tuple of (positions, velocities) tensors.
+        """
+        return self._scene.querier.get_joint_state(entity_name)
+
+    def get_root_state(
+        self, entity_name: str
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+        """Get root pose and velocity for an entity.
+
+        Args:
+            entity_name: Name of the entity.
+
+        Returns:
+            Tuple of (position, quaternion, linear_velocity, angular_velocity).
+        """
+        return self._scene.querier.get_root_state(entity_name)
+
+    def step(self) -> None:
+        """Step the physics simulation by one timestep."""
+        self._scene.controller.step()
+
+    def reset(self, env_ids: torch.Tensor = None) -> None:
+        """Reset specified environments to initial state.
+
+        Args:
+            env_ids: Environment indices to reset. If None, resets all.
+        """
+        self._scene.controller.reset(env_ids=env_ids)
+
+    def set_joint_targets(
+        self,
+        entity_name: str,
+        targets: torch.Tensor,
+        control_type: str = "position",
+    ) -> None:
+        """Set joint control targets for an entity.
+
+        Args:
+            entity_name: Name of the entity.
+            targets: Target values.
+            control_type: Type of control ('position', 'velocity', or 'torque').
+        """
+        self._scene.controller.set_joint_targets(entity_name, targets, control_type)
+
+    @property
+    def scene(self) -> "LabScene":
+        """Access the underlying LabScene instance."""
+        return self._scene

--- a/third_party/setup_third_party.sh
+++ b/third_party/setup_third_party.sh
@@ -5,7 +5,7 @@ set -e
 # Config
 # ============================================================
 
-YAML_FILE="${THIRD_PARTY_YAML:-$(dirname "$0")/third_party_repos.yaml"
+YAML_FILE="${THIRD_PARTY_YAML:-$(dirname "$0")/third_party_repos.yaml}"
 
 # ============================================================
 # Utility functions


### PR DESCRIPTION
## Summary

This PR includes the full set of changes from my recent work branch, not only the minimal fix for issue #1.

### Included commits
- `346128c` fix setup environment scripts and dependency config
- `ec9e7bd` adapt tests to current scene and manager APIs
- `d344029` update README for adapted validation scripts

## What changed

### 1. Add missing engine binding module
- Added `genesislab.engine.binding.GenesisBinding` in `source/genesislab/genesislab/engine/binding.py`.
- This restores the import path used by the validation scripts and resolves the missing module error reported in issue #1.
- The binding exposes scene build/reset/step, joint state queries, root state queries, and joint target setting through the current scene controller/querier stack.

### 2. Adapt validation tests to the current API
Updated the validation scripts to match the current GenesisLab scene and manager APIs:
- `scripts/test/test_engine.py`
- `scripts/test/test_env_vectorized.py`
- `scripts/test/test_env_random_rollout.py`

Main compatibility updates:
- Use `genesislab.engine.assets.robot_cfg.RobotCfg`.
- Use `SceneCfg.SimOptionsCfg(...)` instead of older flat scene timing fields.
- Use `TerrainCfg(type="plane")` instead of older terrain dict patterns.
- Use `ManagerBasedRlEnv` for the manager-based RL validation environment.
- Update the random rollout test to work with the current manager configuration style while preserving the original test logic as much as possible.
- Replace legacy `_binding` access in tests with the current scene-based access pattern where needed.

### 3. Update README validation instructions
Updated `README.md` so the documented validation commands and file references match the current repository layout:
- replace outdated test script references
- point users to `scripts/test/test_env_random_rollout.py`
- remove stale references to deleted/renamed test entries
- fix the validation script list accordingly

### 4. Include setup-related branch changes
This PR also includes the previously committed setup/dependency adjustments already present on the branch:
- `fix setup environment scripts and dependency config`

## Validation

I verified the adapted validation flow locally in the `genesislab` conda environment.

Successful checks included:
- `python scripts/test/test_env_random_rollout.py`
- the updated random rollout test completes successfully and prints `All random rollout tests passed`

## Issue

Closes #1

Issue link: https://github.com/Renforce-Dynamics/genesislab/issues/1